### PR TITLE
Add Either monad with monad methods.

### DIFF
--- a/Monads.Standard.Tests/Monads.Standard.Tests.csproj
+++ b/Monads.Standard.Tests/Monads.Standard.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;net462;net47;net471;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;net462;net47;net471;net472</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/Monads.Standard.Tests/TestDoubles/TestService.cs
+++ b/Monads.Standard.Tests/TestDoubles/TestService.cs
@@ -1,38 +1,60 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Bogus;
+using Monads.Extensions;
+using NUnit.Framework;
 
-namespace Monads.Tests.TestDoubles {
+namespace Monads.Tests.TestDoubles
+{
+    [TestFixture]
     public class TestService
     {
         public Either<EntityDto, string[]> AddOrUpdate(EntityDto dto)
         {
             var existing = Get(dto.RowGuid);
-            return existing.HasValue
-                ? Either.Right<EntityDto, string[]>(dto)
-                : Either.Left<EntityDto, string[]>(new[] {"The specified entity was not found"})
-                        .Chain(right =>
-                               {
-                                   var subEntities = right.SubEntities.Select(x => SubEntity.Create(x.Name, x.OrderDueDate, x.Employees)).ToList();
-                                   var errors = subEntities.Where(x => x.IsLeft).ToList();
-                                   if (errors.Any())
-                                       return Either.Left<(EntityDto dto, SubEntity[] subEntities), string[]>(errors.SelectMany(x => x.Left).Select(x => $"{x.PropertyName}: {string.Join(Environment.NewLine, x.ErrorMessages)}").ToArray());
+            return (existing.HasValue
+                       ? Either.Right<EntityDto, string[]>(dto)
+                       : Either.Left<EntityDto, string[]>(new[] {"The specified entity was not found"}))
+                  .Chain(ConvertSubEntities)
+                  .Chain(right => ConvertEntity(right.dto, right.subEntities))
+                  .Chain(right => Either.Right<EntityDto, string[]>(dto));
+        }
 
-                                   return Either.Right<(EntityDto dto, SubEntity[] subEntities), string[]>((right, subEntities.Select(x => x.Right).ToArray()));
-                               })
-                        .Chain(right =>
-                               {
-                                   var entity = Entity.Create(right.dto.Balance, right.dto.Notes, right.subEntities.ToList());
-                                   if (entity.IsLeft)
-                                       return Either.Left<EntityDto, string[]>(entity.Left.Select(x => $"{x.PropertyName}: {string.Join(Environment.NewLine, x.ErrorMessages)}").ToArray());
+        private Either<Entity, string[]> ConvertEntity(EntityDto dto, ICollection<SubEntity> subEntities)
+        {
+            var entity = Entity.Create(dto.Balance, dto.Notes, subEntities.ToList());
+            if (entity.IsLeft)
+                return Either.Left<Entity, string[]>(entity.Left.Select(x => $"{x.PropertyName}: {string.Join(Environment.NewLine, x.ErrorMessages)}").ToArray());
 
-                                   return Either.Right<EntityDto, string[]>(right.dto);
-                               });
+            return Either.Right<Entity, string[]>(entity.Right);
+        }
+
+        public async Task<Either<EntityDto, string[]>> AddOrUpdateAsync(EntityDto dto)
+        {
+            var existing = await GetAsync(dto.RowGuid);
+            return await (existing.HasValue
+                             ? Either.Right<EntityDto, string[]>(dto)
+                             : Either.Left<EntityDto, string[]>(new[] {"The specified entity was not found"}))
+                        .ChainAsync(async right => ConvertSubEntities(right))
+                        .ChainAsync(async right => ConvertEntity(right.dto, right.subEntities))
+                        .ChainAsync(async right => Either.Right<EntityDto, string[]>(dto));
+        }
+
+        private Either<(EntityDto dto, SubEntity[] subEntities), string[]> ConvertSubEntities(EntityDto dto)
+        {
+            var subEntities = dto.SubEntities.Select(x => SubEntity.Create(x.Name, x.OrderDueDate, x.Employees)).ToList();
+            var errors = subEntities.Where(x => x.IsLeft).ToList();
+            if (errors.Any())
+                return Either.Left<(EntityDto dto, SubEntity[] subEntities), string[]>(errors.SelectMany(x => x.Left).Select(x => $"{x.PropertyName}: {string.Join(Environment.NewLine, x.ErrorMessages)}").ToArray());
+
+            return Either.Right<(EntityDto dto, SubEntity[] subEntities), string[]>((dto, subEntities.Select(x => x.Right).ToArray()));
         }
 
         private Maybe<Entity> Get(Guid rowGuid)
         {
-            if(rowGuid == Guid.Empty)
+            if (rowGuid == Guid.Empty)
                 return Maybe<Entity>.Empty();
 
             Randomizer.Seed = new Random(8675309);
@@ -50,6 +72,40 @@ namespace Monads.Tests.TestDoubles {
                         .RuleFor(x => x.SubEntities, x => subEntities.Generate(x.Random.Int()));
 
             return entity.Generate();
+        }
+
+        private async Task<Maybe<Entity>> GetAsync(Guid rowGuid)
+        {
+            if (rowGuid == Guid.Empty)
+                return Maybe<Entity>.Empty();
+
+            Randomizer.Seed = new Random(8675309);
+
+            var subEntities = new Faker<SubEntity>()
+               .RulesForEntityBase()
+                             .RuleFor(x => x.Name, x => x.Random.String())
+                             .RuleFor(x => x.OrderDueDate, x => DateTime.UtcNow.Date.AddDays(x.Random.Double(2, 366)))
+                             .RuleFor(x => x.Employees, x => x.Random.WordsArray(3, 500).ToList());
+
+            var entity = new Faker<Entity>()
+                        .RulesForEntityBase()
+                        .RuleFor(x => x.Balance, x => x.Random.Decimal(.01m, 1000m))
+                        .RuleFor(x => x.Notes, x => x.Random.String())
+                        .RuleFor(x => x.SubEntities, x => subEntities.Generate(x.Random.Int()));
+
+            return entity.Generate();
+        }
+
+        [Test]
+        public void SmokeTest()
+        {
+            var result = AddOrUpdate(new EntityDto());
+        }
+
+        [Test]
+        public async Task SmokeTestAsync()
+        {
+            var result = await AddOrUpdateAsync(new EntityDto());
         }
     }
 }

--- a/Monads.Standard/Either.cs
+++ b/Monads.Standard/Either.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Monads
 {
@@ -105,6 +106,30 @@ namespace Monads
         public Either<T, TFailure> Chain<T>(Func<TSuccess, Either<T, TFailure>> right)
         {
             return Map(right, left => left);
+        }
+
+        /// <summary>
+        /// Shorthand for <see cref="Map{T,TFailure}" /> when <typeparamref name="TFailure" /> is
+        /// the same for the new either.
+        ///
+        /// Includes shorthand parameters for creating a Right or Left either.
+        /// </summary>
+        /// <typeparam name="T">The <typeparamref name="TSuccess" /> for the resulting either.</typeparam>
+        /// <param name="right">The function to be applied when the either <see cref="IsRight"/>.</param>
+        /// <example>
+        /// <c>
+        ///     either.Chain((right, makeRight, makeLeft) => {
+        ///         var result = DoSomething();
+        ///         if(result)
+        ///             return makeRight(someSuccessValue);
+        ///
+        ///         return makeLeft(someFailureValue);
+        ///     }
+        /// </c>    
+        /// </example>
+        public Either<T, TFailure> Chain<T>(Func<TSuccess, Func<T, Either<T, TFailure>>, Func<TFailure, Either<T, TFailure>>, Either<T, TFailure>> right)
+        {
+            return Map(r => right(r, Either.Right<T, TFailure>, Either.Left<T, TFailure>), left => left);
         }
 
         /// <summary>

--- a/Monads.Standard/Extensions/EitherExtensions.cs
+++ b/Monads.Standard/Extensions/EitherExtensions.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Monads.Extensions
+{
+    public static class EitherExtensions
+    {
+        //source: https://davefancher.com/2015/12/11/functional-c-chaining-async-methods/
+        public static async Task<TResult> MapAsync<TSource, TResult>(
+            this Task<TSource> @this,
+            Func<TSource, Task<TResult>> fn) => await fn(await @this);
+
+        public static async Task<TResult> MapAsync<TSource, TResult>(
+            this TSource @this,
+            Func<TSource, Task<TResult>> fn) => await fn(@this);
+
+        public static async Task<TResult> MapAsync<TSource, TResult>(
+            this Task<TSource> @this,
+            Func<TSource, TResult> fn) => fn(await @this);
+
+        public static async Task<Either<TNewSuccess, TFailure>> ChainAsync<TSuccess, TFailure, TNewSuccess>(this Either<TSuccess, TFailure> @this, Func<TSuccess, Task<Either<TNewSuccess, TFailure>>> right)
+        {
+            return @this.IsLeft 
+                ? Either.Left<TNewSuccess, TFailure>(@this.Left)
+                : await right(@this.Right);
+        }
+
+        public static async Task<Either<TNewSuccess, TFailure>> ChainAsync<TSuccess, TFailure, TNewSuccess>(this Task<Either<TSuccess, TFailure>> @this, Func<TSuccess, Task<Either<TNewSuccess, TFailure>>> right)
+        {
+            var either = await @this;
+            return either.IsLeft 
+                ? Either.Left<TNewSuccess, TFailure>(either.Left)
+                : await right(either.Right);
+        }
+
+        public static async Task<Either<TNewSuccess, TFailure>> ChainAsync<TSuccess, TFailure, TNewSuccess>(this Task<Either<TSuccess, TFailure>> @this, Func<TSuccess, Either<TNewSuccess, TFailure>> right)
+        {
+            var either = await @this;
+            return either.Chain(right);
+        }
+    }
+}

--- a/Monads.Standard/Monads.Standard.csproj
+++ b/Monads.Standard/Monads.Standard.csproj
@@ -2,16 +2,15 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      netstandard1.0;netstandard1.1;netstandard1.2;netstandard1.3;netstandard1.4;netstandard1.5;netstandard1.6;netstandard2.0;netstandard2.1;netcoreapp1.0;netcoreapp1.1;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;net462;net47;net471;net472
+      netstandard1.0;netstandard1.1;netstandard1.2;netstandard1.3;netstandard1.4;netstandard1.5;netstandard1.6;netstandard2.0;netcoreapp1.0;netcoreapp1.1;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;net462;net47;net471;net472
     </TargetFrameworks>
     <RootNamespace>Monads</RootNamespace>
     <AssemblyName>Monads</AssemblyName>
-    <Version>1.3.0-pre-0004</Version>
     <PackageId>Darthruneis.Monads</PackageId>
     <Authors>Chris Thompson</Authors>
     <Company />
     <Product />
-    <Description>Contains core monad implementations including Maybe and Result for general use.</Description>
+    <Description>Contains core monad implementations including Maybe and Either for general use.</Description>
     <PackageTags>utility status monad monads result maybe generic either</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageReleaseNotes>New: Add new Monad - 'Either'. Semi-replacement for 'Result' monad.</PackageReleaseNotes>
@@ -20,14 +19,15 @@
     <RepositoryUrl>https://github.com/Darthruneis/Monads</RepositoryUrl>
     <RepositoryType>Github</RepositoryType>
     <PackageProjectUrl>https://github.com/users/Darthruneis/projects/1</PackageProjectUrl>
+    <DocumentationFile>C:\git\Monads\Monads.Standard\Monads.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>C:\git\Monads\Monads.Standard\Monads.xml</DocumentationFile>
+    <Version>1.3.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>C:\git\Monads\Monads.Standard\Monads.xml</DocumentationFile>
+    <Version>1.3.0-pre-$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Monads.Standard/Monads.xml
+++ b/Monads.Standard/Monads.xml
@@ -68,6 +68,27 @@
             Replace <c>.Map(rightFunc, left => left)</c> with <c>.Chain(rightFunc)</c>.
             </example>
         </member>
+        <member name="M:Monads.Either`2.Chain``1(System.Func{`0,System.Func{``0,Monads.Either{``0,`1}},System.Func{`1,Monads.Either{``0,`1}},Monads.Either{``0,`1}})">
+             <summary>
+             Shorthand for <see cref="M:Monads.Either`2.Map``2(System.Func{`0,Monads.Either{``0,``1}},System.Func{`1,``1})" /> when <typeparamref name="TFailure" /> is
+             the same for the new either.
+            
+             Includes shorthand parameters for creating a Right or Left either.
+             </summary>
+             <typeparam name="T">The <typeparamref name="TSuccess" /> for the resulting either.</typeparam>
+             <param name="right">The function to be applied when the either <see cref="P:Monads.Either`2.IsRight"/>.</param>
+             <example>
+             <c>
+                 either.Chain((right, makeRight, makeLeft) => {
+                     var result = DoSomething();
+                     if(result)
+                         return makeRight(someSuccessValue);
+            
+                     return makeLeft(someFailureValue);
+                 }
+             </c>    
+             </example>
+        </member>
         <member name="M:Monads.Either`2.Apply(System.Action{`0})">
             <summary>
             Applies the provided <paramref name="action" /> when <see cref="P:Monads.Either`2.IsRight" />.

--- a/publish-nuget.ps1
+++ b/publish-nuget.ps1
@@ -4,12 +4,20 @@ param(
     [Parameter(Mandatory=$true,Position=0)]
     [string] $version,
     [Parameter(Mandatory=$true,Position=1)]
-    [string] $key
+    [string] $key,
+    [Parameter(Mandatory=$false,Position=2)]
+    [switch] $release
 )
 
-if($PSCmdlet.ShouldProcess("./Monads.Standard/bin/Release/Darthruneis.Monads.$version.nupkg", "Nuget-Push"))  {
-    (dotnet nuget push "./Monads.Standard/bin/Release/Darthruneis.Monads.$version.nupkg" -k $key -s https://api.nuget.org/v3/index.json)
+$binFolder = "Debug";
+if($release) {
+    $binFolder = "Release";
+}
+
+
+if($PSCmdlet.ShouldProcess("./Monads.Standard/bin/$binFolder/Darthruneis.Monads.$version.nupkg", "Nuget-Push"))  {
+    (dotnet nuget push "./Monads.Standard/bin/$binFolder/Darthruneis.Monads.$version.nupkg" -k $key -s https://api.nuget.org/v3/index.json)
 }
 else {
-    Write-Information ("Would have pushed " + "./Monads.Standard/bin/Release/Darthruneis.Monads.$version.nupkg" + "to https://api.nuget.org/v3/index.json using key $key")
+    Write-Information ("Would have pushed " + "./Monads.Standard/bin/$binFolder/Darthruneis.Monads.$version.nupkg" + "to https://api.nuget.org/v3/index.json using key $key")
 }


### PR DESCRIPTION
Set up test project to target multiple frameworks.
- Can not run tests on NetStandard.
- No support on GitHub for NetStandard2.1 and NetCore3.0. Would like support later.

Licensing, project/repo URLs.

Reworked Map/Chain after experimenting with it.

Add async support for Either.

Better async support.

Chain overload which allows for more succint code.

Automatic prerelease versioning using datetime.

Publish script support for Release vs Debug builds.